### PR TITLE
working ssl & building contract submodule

### DIFF
--- a/circles-api/dev.tf
+++ b/circles-api/dev.tf
@@ -118,5 +118,6 @@ module "ecs" {
   database_password   = "${var.database_password}"
   database_port       = "${var.database_port}"
   android_platform_gcm_arn    = "${data.terraform_remote_state.circles_sns.gcm_platform_arn}"
-  private_key         = "${var.private_key}"  
+  private_key         = "${var.private_key}" 
+  ssl_certificate_arn = "${aws_acm_certificate.cert.arn}"
 }

--- a/circles-api/modules/code_pipeline/buildspec_test.yml
+++ b/circles-api/modules/code_pipeline/buildspec_test.yml
@@ -2,17 +2,25 @@ version: 0.2
 
 phases:
   pre_build:
-    commands:       
+    commands:     
+      - echo Entered the pre_build phase...  
       - API_VERSION="v$( node -p "require('./package.json').version" )"
       - export API_VERSION
       - echo Installing node packages ...      
       - npm install
-      - echo Entered the pre_build phase...
+      - echo Installing and compiling contracts ...
+      - mkdir contracts
+      - cd contracts
+      - git clone https://github.com/CirclesUBI/circles-contracts.git .
+      - npm install
+      - npx truffle compile
+      - cd ..
   build:
     commands:
       - echo Build started on `date`
       - echo Starting migrations ...
       - npm run migrate:up
+      - echo Starting tests ...
       - npm test
   post_build:
     commands:

--- a/circles-api/modules/ecs/variables.tf
+++ b/circles-api/modules/ecs/variables.tf
@@ -69,3 +69,7 @@ variable "android_platform_gcm_arn" {
 variable "private_key" {
   description = "The user's private key"
 }
+
+variable "ssl_certificate_arn" {
+  description = "SSL Cert for the API"  
+}


### PR DESCRIPTION
This PR adds SSL cert generation and pinning to the ECS load balancer.

Also, build pipeline now clones the `contracts` submodule and compiles contracts so that the relevant API endpoints can be tested.