### PR TITLE
cafe grundeinkommen website

### DIFF
--- a/cafe-grundeinkommen-website/main.tf
+++ b/cafe-grundeinkommen-website/main.tf
@@ -1,0 +1,37 @@
+terraform {
+  backend "s3" {
+    bucket         = "cafe-grundeinkommen-website-terraform-state"
+    region         = "eu-central-1"
+    key            = "cafe-grundeinkommen-website-terraform.tfstate"
+    dynamodb_table = "cafe-grundeinkommen-website-terraform"
+    encrypt        = true
+  }
+}
+
+provider "aws" {
+  access_key = "${var.access_key}"
+  secret_key = "${var.secret_key}"
+  region     = "${var.aws_region}"
+}
+
+resource "aws_lightsail_key_pair" "cafe" {
+  name   = "cafe-grundeinkommen-website-key"
+  public_key = "${file("ssh/cafe-grundeinkommen-website.pub")}"
+}
+
+resource "aws_lightsail_static_ip" "cafe" {
+  name = "cafe-grundeinkommen-website-ip"
+}
+
+resource "aws_lightsail_static_ip_attachment" "cafe" {
+  static_ip_name = "${aws_lightsail_static_ip.cafe.name}"
+  instance_name  = "${aws_lightsail_instance.cafe.name}"
+}
+
+resource "aws_lightsail_instance" "cafe" {
+  name              = "cafe-grundeinkommen-wordpress"
+  availability_zone = "${var.aws_region}b"
+  blueprint_id      = "${var.blueprint_id}"
+  bundle_id         = "${var.instance_size}_2_0"
+  key_pair_name     = "${aws_lightsail_key_pair.cafe.name}"
+}

--- a/cafe-grundeinkommen-website/variables.tf
+++ b/cafe-grundeinkommen-website/variables.tf
@@ -1,0 +1,19 @@
+variable "access_key" {
+  description = "AWS access key"
+}
+
+variable "secret_key" {
+  description = "AWS secret access key"
+}
+
+variable "aws_region" {
+  description = "The AWS region to create things in."
+}
+
+variable "blueprint_id" {
+  description = "Blueprint for lightsail instance."  
+}
+
+variable "instance_size" {
+  description = "Size of lightsail instance"  
+}


### PR DESCRIPTION
Using AWS lightsail, we can have add a way to setup SSL certs automatically later when we are ready to go live.

https://www.terraform.io/docs/providers/acme/dns_providers/lightsail.html

This is currently not deployed, as we are waiting on input from the web designer. 